### PR TITLE
Fixed type_cast issue

### DIFF
--- a/lib/delocalize/rails_ext/active_record_rails42.rb
+++ b/lib/delocalize/rails_ext/active_record_rails42.rb
@@ -61,13 +61,6 @@ end
 
 module ActiveRecord
   module Type
-    class Decimal
-      def type_cast_from_user(value)
-        value = ::Numeric.parse_localized(value)
-        type_cast(value)
-      end
-    end
-
     class Time
       def type_cast_from_user(value)
         value = ::Time.parse_localized(value) rescue value

--- a/lib/delocalize/rails_ext/active_record_rails42.rb
+++ b/lib/delocalize/rails_ext/active_record_rails42.rb
@@ -97,3 +97,11 @@ module ActiveRecord
     end
   end
 end
+
+module ActiveRecord
+  class Attribute
+    def value_before_type_cast
+      type.number? ? ::Numeric.parse_localized(@value_before_type_cast) : @value_before_type_cast
+    end
+  end
+end


### PR DESCRIPTION
 - [x] @johnny-lai 

https://coupadev.atlassian.net/browse/CD-51689

We have  bug with type_cast and delocalize gem again.
example: 
```ruby
a = Contract.first
b.savings_pct  => 0.0
```

In Rails_4_1
```ruby
[1] pry(....)> b.savings_pct = '-1,000.0'
=> "-1,000.0"
[2] pry(...)> b.savings_pct
=> -1000.0
[3] pry(...)> b.savings_pct_before_type_cast
=> "-1000.0"
```
In Rails_4_2
```ruby
[1] pry(...)> b.savings_pct = '-1,000.0'
=> "-1,000.0"
[2] pry(...)> b.savings_pct
=> -1000.0
[3] pry(...)> b.savings_pct_before_type_cast
=> "-1,000.0"
```

As can you see, `savings_pct_before_type_cast` is deferent between version. This is BAD, because we have problem in validator.

Please take a look. We have validator `validates_numericality_of` ( https://github.com/coupa/coupa_development/blob/master_rails_4_2/app/models/contract.rb#L299). This validator take `savings_pct_before_type_cast`  ( https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validations/numericality.rb#L23), so we have error(`is not a number`).

Thats why I added code to gem. After that  `savings_pct_before_type_cast` return correct value.


Here is test branch with this changes https://github.com/coupa/coupa_development/pull/29170