### PR TITLE
CD-60657 Number custom field doesn't get a proper value when locale is in German

### DIFF
--- a/lib/delocalize/rails_ext/active_record_rails42.rb
+++ b/lib/delocalize/rails_ext/active_record_rails42.rb
@@ -91,10 +91,15 @@ module ActiveRecord
   end
 end
 
+#
+# This value_before_type_cast override was added to maintain the same behavior in 4.2 (for v16.0).
+# Without this, in Rails 4.2, Numeric value validation fails with localized format (the value user enters) in non-US format locales.
+# [Because, before Rails 4.2, attribute_before_type_cast returned US-format, but it returns localized format in 4.2.]
+#
 module ActiveRecord
   class Attribute
     def value_before_type_cast
-      type.number? ? ::Numeric.parse_localized(@value_before_type_cast) : @value_before_type_cast
+      type.number? && came_from_user? ? ::Numeric.parse_localized(@value_before_type_cast) : @value_before_type_cast
     end
   end
 end


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CD-60657)
* [JIRA propagation subtask](https://coupadev.atlassian.net/browse/CD-61216)

## Code reviewers

- [x] @johnny-lai 
- [x] @aergonaut 

## Summary of issue

- Changes made in delocalize gem caused a regression in Numeric Custom Field (when it's read from database) in German locale

## Summary of change

- The code change was originally reviewed in #32555
- Looks like we've not updated the gem version when we added our own code, so I just followed the same way (didn't increment gem version, changed the commit SHA in Gemfile.lock instead).
- value_before_type_cast override broke Numeric Custom Field in German locale or whatever locale which uses dot ('.') character as a thousand delimiter.
- Because Numeric CF is stored as varchar in db and we mutate it by modifying column type from string to decimal (i.e. parse_localized are applied for string).
- Serialized data for Num CF in db is in US format string which should not be applied parse_localized in non-US locale when it's read from database.

## Testing approach

- Manually tested in Cart with Numeric CF
- Manually tested in Expense with Numeric CF and Expense Category dependent Numeric CF
- And all tests had passed in #32555 with the same change (applied by a monkey patch)