### PR TITLE
CD-62205 CD-62261 0-4-coupa Dates for en-AU locale aren't being stored correctly on backend

### DIFF
--- a/lib/delocalize/localized_date_time_parser.rb
+++ b/lib/delocalize/localized_date_time_parser.rb
@@ -8,12 +8,14 @@ module Delocalize
       '%B' => "(#{Date::MONTHNAMES.compact.join('|')})",      # long month name
       '%b' => "(#{Date::ABBR_MONTHNAMES.compact.join('|')})", # short month name
       '%m' => "(\\d{1,2})",                                   # numeric month
+      '%-m' => "(\\d{1,2})",                                  # numeric month (no padding)
       '%A' => "(#{Date::DAYNAMES.join('|')})",                # full day name
       '%a' => "(#{Date::ABBR_DAYNAMES.join('|')})",           # short day name
       '%Y' => "(\\d{4})",                                     # long year
       '%y' => "(\\d{2})",                                     # short year
       '%e' => "(\\s\\d|\\d{2})",                              # short day
       '%d' => "(\\d{1,2})",                                   # full day
+      '%-d' => "(\\d{1,2})",                                  # full day (no padding)
       '%H' => "(\\d{2})",                                     # hour (24)
       '%M' => "(\\d{2})",                                     # minute
       '%S' => "(\\d{2})"                                      # second
@@ -29,6 +31,8 @@ module Delocalize
         input_formats(type).each do |original_format|
           next unless datetime =~ /^#{apply_regex(original_format)}$/
 
+          # strptime doesn't accept '%-m' nor '%-d' format while it needs to be feeded into strftime in that format
+          original_format.gsub!(/%-m|%-d/, "%-m" => "%m", "%-d" => "%d")
           datetime = DateTime.strptime(datetime, original_format)
           return Date == type ?
             datetime.to_date :


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CD-62205)
* [JIRA propagation subtask](https://coupadev.atlassian.net/browse/CD-62261)

## Code reviewers

- [ ] @johnny-lai 
- [x] @farrspace

## Summary of issue

- In en-AU locale, date isn't properly stored in the database. Sep 1st, 2016 is noted as '1/9/16' in en-AU locale becomes Sep 16th, 2001.

## Summary of change

- Added support for formats, '%-d' (no padded day of the month) and '%-m' (no padded month of the year)

## Testing approach

- Manually verified that expense line and cart line store date as expected in en-AU into db
- Added/ran unit tests in enterprise (it's not in this pr)

