### PR TITLE
CD-74432 CD-74452 0-4-coupa delocalize parse_localize breaks date format of translation hash in memory

### DIFF
--- a/lib/delocalize/localized_date_time_parser.rb
+++ b/lib/delocalize/localized_date_time_parser.rb
@@ -32,8 +32,8 @@ module Delocalize
           next unless datetime =~ /^#{apply_regex(original_format)}$/
 
           # strptime doesn't accept '%-m' nor '%-d' format while it needs to be feeded into strftime in that format
-          original_format.gsub!(/%-m|%-d/, "%-m" => "%m", "%-d" => "%d")
-          datetime = DateTime.strptime(datetime, original_format)
+          adjusted_format = original_format.gsub(/%-m|%-d/, "%-m" => "%m", "%-d" => "%d")
+          datetime = DateTime.strptime(datetime, adjusted_format)
           return Date == type ?
             datetime.to_date :
             Time.zone.local(datetime.year, datetime.mon, datetime.mday, datetime.hour, datetime.min, datetime.sec)


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CD-74432)
* [JIRA propagation subtask](https://coupadev.atlassian.net/browse/CD-74452)

## Code reviewers

- [x] @farrspace  
- [x] @mudiarto 

## Summary of issue

- The commit 5f210d59 broke ```i18n``` simple backend' translation hash when either of the formats, "%-d" or "%-m" is included in date format.

## Summary of change

- changed not to overwrite the i18n simple backend's translation hash

## Testing approach

- Manually tested with local instance of enterprise using this revision of delocalize gem and verified the issue is no longer reproducible in en-AU locale.

