### PR TITLE
CD-132664 [5.0] ActionView::Template::Error: undefined method `default_shipping_term_id'

### DIFF
--- a/lib/delocalize/rails_ext/action_view_rails42.rb
+++ b/lib/delocalize/rails_ext/action_view_rails42.rb
@@ -7,7 +7,10 @@ ActionView::Helpers::Tags::TextField.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def render_with_localization
-    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && object.respond_to?(:column_for_attribute) && column = object.column_for_attribute(@method_name)
+    if object &&
+       (@options[:value].blank? || !@options[:value].is_a?(String)) &&
+       (object.respond_to?(:has_attribute?) && object.has_attribute?(@method_name))
+      column = object.column_for_attribute(@method_name)
       value = @options[:value] || object.send(@method_name)
 
       if column.number?


### PR DESCRIPTION
reviewers:
- [x] @johnny-lai 
- [x] @dkirilenko 

#### Summary of issue
Now [`column_for_attribute`](https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/attribute_methods.rb#L182) returns special class instead of `nil`. `has_attribute?` method has  to  be used instead.