### PR TITLE
CD-200184: rails 5.2 : Update localized_date_time_parser.rb to dup the datetime since ActiveSupport returns frozen string

### DIFF
--- a/lib/delocalize/localized_date_time_parser.rb
+++ b/lib/delocalize/localized_date_time_parser.rb
@@ -66,7 +66,7 @@ module Delocalize
         end.flatten.compact
 
         original = (Date::MONTHNAMES + Date::ABBR_MONTHNAMES + Date::DAYNAMES + Date::ABBR_DAYNAMES).compact
-        translated.each_with_index { |name, i| datetime.gsub!(/\b#{name}\b/, original[i]) }
+        translated.each_with_index { |name, i| datetime.dup.gsub!(/\b#{name}\b/, original[i]) }
       end
 
       def input_formats(type)

--- a/lib/delocalize/localized_date_time_parser.rb
+++ b/lib/delocalize/localized_date_time_parser.rb
@@ -66,7 +66,10 @@ module Delocalize
         end.flatten.compact
 
         original = (Date::MONTHNAMES + Date::ABBR_MONTHNAMES + Date::DAYNAMES + Date::ABBR_DAYNAMES).compact
-        translated.each_with_index { |name, i| datetime.dup.gsub!(/\b#{name}\b/, original[i]) }
+        #+str → str (mutable)
+        #If the string is frozen, then return duplicated mutable string.
+        datetime = +datetime
+        translated.each_with_index { |name, i| datetime.gsub!(/\b#{name}\b/, original[i]) }
       end
 
       def input_formats(type)


### PR DESCRIPTION
ActiveSupport 5.2 returns frozen string
[CD-200184](https://coupadev.atlassian.net/browse/CD-200184)
- [ ] @cmayor 

```
[36] pry(main)> Time.zone.now
=> Mon, 18 May 2020 11:35:23 UTC +00:00
[37] pry(main)> Time.zone.now.to_s.frozen?
=> true
[38] pry(main)> Time.zone.now.to_s.gsub!(/[2020]/, '*')
FrozenError: can't modify frozen String
from (pry):32:in `gsub!'
[39] pry(main)> Time.zone.now.to_s.dup.gsub!(/[2020]/, '*')
=> "****-*5-18 11:35:34 UTC"
```

